### PR TITLE
Fix imports and add a typer CLI to chemdash.

### DIFF
--- a/.idea/runConfigurations/chemdash_docker.xml
+++ b/.idea/runConfigurations/chemdash_docker.xml
@@ -1,0 +1,55 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="chemdash docker" type="PythonConfigurationType" factoryName="Python">
+    <module name="chemdash" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Remote Python 3.10.12 Docker (chemdash:latest)" />
+    <option name="WORKING_DIRECTORY" value="/opt/chemdash/" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="DockerContainerSettingsRunConfigurationExtension">
+      <option name="envVars">
+        <list />
+      </option>
+      <option name="extraHosts">
+        <list />
+      </option>
+      <option name="links">
+        <list />
+      </option>
+      <option name="networkDisabled" value="false" />
+      <option name="networkMode" value="bridge" />
+      <option name="portBindings">
+        <list />
+      </option>
+      <option name="publishAllPorts" value="false" />
+      <option name="runCliOptions" value="--platform linux/amd64 --rm --entrypoint=/opt/chemdash/chemdash.py -p 8000:8000" />
+      <option name="version" value="2" />
+      <option name="volumeBindings">
+        <list />
+      </option>
+    </EXTENSION>
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <PathMappingSettings>
+      <option name="pathMappings">
+        <list>
+          <mapping local-root="$PROJECT_DIR$" remote-root="/opt/chemdash" />
+        </list>
+      </option>
+    </PathMappingSettings>
+    <option name="SCRIPT_NAME" value="chemdash.py" />
+    <option name="PARAMETERS" value="" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/chemdash_venv.xml
+++ b/.idea/runConfigurations/chemdash_venv.xml
@@ -1,0 +1,47 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="chemdash venv" type="PythonConfigurationType" factoryName="Python">
+    <module name="chemdash" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="DockerContainerSettingsRunConfigurationExtension">
+      <option name="envVars">
+        <list />
+      </option>
+      <option name="extraHosts">
+        <list />
+      </option>
+      <option name="links">
+        <list />
+      </option>
+      <option name="networkDisabled" value="false" />
+      <option name="networkMode" value="bridge" />
+      <option name="portBindings">
+        <list />
+      </option>
+      <option name="publishAllPorts" value="false" />
+      <option name="runCliOptions" value="--platform linux/amd64 --rm --entrypoint=/opt/chemdash/chemdash.py -p 8000:8000" />
+      <option name="version" value="2" />
+      <option name="volumeBindings">
+        <list />
+      </option>
+    </EXTENSION>
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="./chemdash.py" />
+    <option name="PARAMETERS" value="" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ RUN python3 -m pip install -r requirements.txt
 COPY . /opt/chemdash
 
 # In production we override with gunicorn, etc. 
-ENTRYPOINT /opt/chemdash/chemdash.py
+ENTRYPOINT ["/opt/chemdash/chemdash.py"]
+CMD ["--help"]
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python3 ./chemdash.py dataset_800.csv --port 8000 --debug
 
 ### PyCharm
 
-The repo contains two PyCharm run configurations, one for running in docker, and the other to work with a local venv.
+The repo contains two PyCharm run configurations, both of which use the venv, each with differen test datasets. 
 You make either of those as above, and then specify either `chemdash venv` or `chemdash docker` to run the respective way.
 
 NOTE: PyCharm debugging works best with the `chemdash venv` option.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker buildx build --platform linux/amd64 -t chemdash:latest .
 
 To start chemdash from the CLI:
 ```
-docker run --rm --name chemdash -p 8000:8000 -v /tmp:/tmp -v /var/tmp:/var/tmp -d chemdash:latest
+docker run --rm --name chemdash -p 8000:8000 -v /tmp:/tmp -v /var/tmp:/var/tmp -d chemdash:latest dataset_800.csv  --port 8000 --debug 
 ```
 
 Then open a browser while watching the logs in the terminal:
@@ -47,7 +47,7 @@ Install non-python dependencies on Mac:
 ```
 
 Install the python dependencies in a virtualenv:
-```
+``
 python3.10 -m venv venv
 . ./venv/bin/activate
 pip install -r requirements.txt
@@ -56,7 +56,7 @@ pip install -r requirements.txt
 To run, make sure your new environment is active and navigate to the directory containing _chemdash.py_ and run it.
 ```
 . venv/bin/activate
-python chemdash.py
+python3 ./chemdash.py dataset_800.csv --port 8000 --debug
 ```
 
 ### PyCharm

--- a/chemdash.py
+++ b/chemdash.py
@@ -88,7 +88,6 @@ def prepare_data(df, fp_type='maccs', plot_type='umap'):
 
     print('Done Cleaning')
     t4 = time.time(); e4 = t4 - t3
-    print(f"{e4} ({t4}")
     print(f"elapsed: {e4} ({t4})")
 
     return df

--- a/chemdash.py
+++ b/chemdash.py
@@ -394,6 +394,5 @@ def main(
 if __name__ == '__main__':
     # NOTE: THe parallelization logic in prepare() will re-load this module in sub-processes,
     # All "real work" is done in this block, with the main module body doing only definitions!
-    import sys
-    print(f"ARGV: {sys.argv}")
-    #typer.run(main)
+    typer.run(main)
+

--- a/chemdash.py
+++ b/chemdash.py
@@ -35,15 +35,16 @@ MAX_COMPOUNDS = 10000
 def prepare_data(df, fp_type='maccs', plot_type='umap'):
     print('canonicalizing smiles')
     t0 = time.time()
-    print(t0)
+    print(f"Start time: {t0}")
     df['canon_smiles'] = df_canonicalize_from_smiles(df, 'smiles')
     print('converting to mols')
     t1 = time.time(); e1 = t1 - t0
-    print(t1)
+    print(f"elapsed: {e1} ({t1})")
     df['mol'] = df_smiles_to_rdkit_mol(df, 'canon_smiles')
     print('generating images')
     t2 = time.time(); e2 = t2 - t1
     print(f"{e2} ({t2}")
+    print(f"elapsed: {e2} ({t2})")
 
     df['Structure'] = parallelize_dataframe_func(df, partial(
         df_get_image_file_url, mol_col='mol', id_col='Compound_id'))
@@ -59,6 +60,9 @@ def prepare_data(df, fp_type='maccs', plot_type='umap'):
     #create Molecular Descriptor object and calc descriptors on the df
     print ('calc mol descriptors')
     print(time.time())
+    t3 = time.time(); e3 = t3 - t2
+    print(f"elapsed: {e3} ({t3})")
+
     md = MolecularDescriptors(mol_field='mol', smiles_field='canon_smiles', id_field='Compound_id')
     df = md.generate_descriptors(df)
 
@@ -83,7 +87,10 @@ def prepare_data(df, fp_type='maccs', plot_type='umap'):
     df = df[df['Compound_id'] != 'Placeholder'].reset_index(drop=True)
 
     print('Done Cleaning')
-    print(time.time())
+    t4 = time.time(); e4 = t4 - t3
+    print(f"{e4} ({t4}")
+    print(f"elapsed: {e4} ({t4})")
+
     return df
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -183,6 +183,8 @@ requests
 retrying==1.3.4
 rope
 ruamel_yaml
+ruamel.yaml  # eliminates certain warnings in pycharm?
+ruamel.yaml.clib
 scikit-image
 scikit-learn
 scipy
@@ -219,6 +221,7 @@ toolz
 tornado
 tqdm
 traitlets
+typer
 umap-learn==0.5.6
 unicodecsv
 urllib3
@@ -233,6 +236,4 @@ xlrd
 xlsxwriter
 xlwings
 xlwt
-ruamel.yaml
-ruamel.yaml.clib
 


### PR DESCRIPTION
This is pretty small cleanup.

### What this changes:
- add a `typer` CLI to `chemdash.py`, w/ specifiable input file and port
- fix the parts of the top-level that conflict with mulitprocessing "spawn"
   - all work previously done at the top level of chemdash.py is in functions
   - real work is only done on import if `__name__ == "__main__"`.
 - update imports to match the newer versions of dash
 - remove the docker run config for pycharm b/c of multiprocessing conflicts

### How to test this:
```
docker buildx build --platform linux/amd64 -t chemdash:latest .
docker run --rm --name chemdash -p 8000:8000 -v /tmp:/tmp -v /var/tmp:/var/tmp chemdash:latest dataset_800.csv  --port 8000
open http://0.0.0.0:8000
```

