### PR TITLE
Install LAP better

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ COPY ./requirements.txt /opt/chemdash/requirements.txt
 ENV PIP_ROOT_USER_ACTION=ignore
 ENV PIP_NO_CACHE_DIR=off
 
-# These two have a dependency resolution order problem.  Handle manually though they are also in requirements.txt
+# We have to install lap from github, and if put into the requirmemts.txt file it gets confused about its deps on numpy.
+# Install everything except LAP, then add LAP directly.
+# NOTE: lap is slow, and we need to replace it.
 RUN python3 -m pip install -r requirements.txt
 RUN python3 -m pip install -e git+https://github.com/gatagat/lap.git@v0.4.0#egg=lap
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,8 @@ ENV PIP_ROOT_USER_ACTION=ignore
 ENV PIP_NO_CACHE_DIR=off
 
 # These two have a dependency resolution order problem.  Handle manually though they are also in requirements.txt
-RUN python3 -m pip install numpy==1.26.4
-RUN python3 -m pip install cython
-RUN python3 -m pip install -e git+https://github.com/gatagat/lap.git@v0.4.0#egg=lap
 RUN python3 -m pip install -r requirements.txt
+RUN python3 -m pip install -e git+https://github.com/gatagat/lap.git@v0.4.0#egg=lap
 
 # Application code.  This updates most frequently but is a cheap rebuild. 
 COPY . /opt/chemdash

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Install the python dependencies in a virtualenv:
 python3.10 -m venv venv
 . ./venv/bin/activate
 pip install -r requirements.txt
+-e git+https://github.com/gatagat/lap.git@v0.4.0#egg=lap
 ```
 
 To run, make sure your new environment is active and navigate to the directory containing _chemdash.py_ and run it.

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,9 +88,8 @@ jupyterlab
 jupyterlab-server
 keyring
 kiwisolver
-lap==0.4.0; platform_machine == "x86_64"
--e git+https://github.com/gatagat/lap.git@v0.4.0#egg=lap
-lapjv==1.3.27; platform_machine == "x86_64"
+# -e git+https://github.com/gatagat/lap.git@v0.4.0#egg=lap  # NOTE: install manually after this whole file
+# lapjv==1.3.27; platform_machine == "x86_64"
 lazy-object-proxy
 libarchive-c
 lief


### PR DESCRIPTION
### What this changes
- remove `lap` an  `lapjv` from the `requirements.txt`.
- add `lap` to be installed from github after the pip requirements

### How this was tested:
- [x] docker build (Linux on Mac M3)
- [x] maual venv creation (direct pip on Mac M3)